### PR TITLE
Support SSE on subdirectory

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var logger = require('nanologger')
 module.exports = reload
 
 function reload (url) {
-  url = url || 'sse'
+  url = url || '/sse'
   return function (state, emitter) {
     var log = logger('sse')
     var source = new window.EventSource(url)


### PR DESCRIPTION
This fixes an issue where `/app/foo` showed an error that `/app/sse` is not available.
I guess that's a decent default